### PR TITLE
Bugfix: windows ensure installation param missing

### DIFF
--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -10,6 +10,11 @@
 #
 # ---
 #
+# [*ensure*]
+# - Default - present
+# - {Puppet Package Ensure Attribute}[http://docs.puppetlabs.com/references/latest/type.html#package-attribute-ensure]
+# - NOTE: currently a NOOP until stackdriver supports proper windows packages
+#
 # [*installer*]
 # - Default - /tmp/Stackdriverinstaller-0.3.exe
 # - Stackdriver Windows installer


### PR DESCRIPTION
currently a NOOP until stackdriver ships a proper windows package
