### PR TITLE
Fixing RabbitMQ plugin module. Tested on puppet 3.6.2

### DIFF
--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -49,15 +49,18 @@
 #
 class stackdriver::plugin::rabbitmq(
 
-  $config   =  '/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf',
+  $pkg      = 'yajl',
+
+  $config   = '/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf',
   $vhost    = '%2F',
-  $port     = '15672',
+  $port     = 15672,
   $queue    = undef,
   $user     = 'guest',
   $password = 'guest',
 
 ) {
 
+  validate_string ( $pkg      )
   validate_string ( $config   )
   validate_string ( $vhost    )
   validate_string ( $port     )
@@ -65,12 +68,10 @@ class stackdriver::plugin::rabbitmq(
   validate_string ( $password )
   validate_string ( $queue    )
 
-  contain "${name}::config"
+  contain "${name}::install"
 
-  # Install package
-  ensure_resource('package', 'yajl', {
-    'ensure'  => 'present',
-  })
+  class { "::${name}::config": require => Class["::${name}::install"] }
+  contain "${name}::config"
 
 }
 

--- a/manifests/plugin/rabbitmq/install.pp
+++ b/manifests/plugin/rabbitmq/install.pp
@@ -1,0 +1,21 @@
+# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2 foldmethod=marker
+#
+# == Class: stackdriver::plugin::rabbitmq::install
+#
+# Installs Rabbitmq Agent Plugin for Stackdriver Agent
+#
+
+class stackdriver::plugin::rabbitmq::install inherits stackdriver::plugin::rabbitmq {
+
+  if ! $pkg {
+    fail("No package defined for OS ${::operatingsystem}")
+  }
+
+  package { [$pkg]:
+    ensure  => 'present', 
+    require => [Package['yum-plugin-s3-iam'], 
+                Package['stackdriver-agent']],
+  }
+
+}
+


### PR DESCRIPTION
Including rabbitmq on my module had caused puppet to fail. This solves the issue. At least on puppet 3.6.2