### PR TITLE
Add plugin for monitoring Zookeeper

### DIFF
--- a/manifests/plugin/zookeeper.pp
+++ b/manifests/plugin/zookeeper.pp
@@ -1,0 +1,56 @@
+# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2 foldmethod=marker
+#
+# == Class: stackdriver::plugin::zookeeper
+#
+# Enable Zookeeper Agent Plugin for Stackdriver Agent
+#
+# === Parameters
+# ---
+#
+# [*config*]
+# - Default - /opt/stackdriver/collectd/etc/collectd.d/zookeeper.conf
+# - Plugin configuration file
+#
+# [*host*]
+# - Default - localhost
+# - Zookeeper instance host
+#
+# [*port*]
+# - Default - 2181
+# - Zookeeper instance port
+#
+# === Usage
+# ---
+#
+# ==== Puppet Code
+#
+#  Enable Zookeeper plugin via Puppet CODE:
+#
+#  include '::stackdriver::plugin::zookeeper'
+#
+# ==== Hiera
+#
+#  Enable Zookeeper plugin via Hiera:
+#
+#  stackdriver::plugins:
+#   - 'zookeeper'
+#
+class stackdriver::plugin::zookeeper(
+
+  $config   =  '/opt/stackdriver/collectd/etc/collectd.d/zookeeper.conf',
+
+  $host 		=  'localhost',
+  $port     =  '2181'
+
+) {
+
+  Class['stackdriver'] -> Class[$name]
+
+  validate_string ( $config )
+  validate_string ( $host   )
+  validate_string ( $port   )
+
+  contain "${name}::config"
+
+}
+

--- a/manifests/plugin/zookeeper/config.pp
+++ b/manifests/plugin/zookeeper/config.pp
@@ -1,0 +1,22 @@
+# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2 foldmethod=marker
+#
+# == Class: stackdriver::plugin::zookeeper::config
+#
+# Configures Zookeeper Agent Plugin for Stackdriver Agent
+#
+class stackdriver::plugin::zookeeper::config(
+
+
+) inherits stackdriver::plugin::zookeeper {
+
+  file { $config:
+    ensure  => file,
+    content => template("stackdriver/${::kernel}/${config}.erb"),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    notify  => Service[$::stackdriver::svc],
+  }
+
+}
+

--- a/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/zookeeper.conf.erb
+++ b/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/zookeeper.conf.erb
@@ -1,0 +1,5 @@
+LoadPlugin "zookeeper"
+<Plugin "zookeeper">
+Host "<%= @host %>"
+Port "<%= @port %>"
+</Plugin>


### PR DESCRIPTION
This follows the steps of setting up monitoring for Zookeeper as documented for Google Cloud Monitoring on https://cloud.google.com/monitoring/agent/plugins/zookeeper