### PR TITLE
Rabbitmq plugin extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,15 +207,24 @@ stackdriver::plugin::elasticsearch::port:      '9200'
 
 ### RabbitMQ
 
-Configures the RabbitMQ plugin on the local host running on port 5672.
-All settings are required.
+Configures the RabbitMQ plugin on the local host running on port 15672.
+The defaults for all settings are listed below.  The queue names must
+be unique and defaults to a null string ('') if not specified.
 
 ```yaml
-stackdriver::plugin::rabbitmq::vhost:     '%2F'
-stackdriver::plugin::rabbitmq::port:      '15672'
-stackdriver::plugin::rabbitmq::queue:     '(Queue Name)'
-stackdriver::plugin::rabbitmq::user:      'guest'
-stackdriver::plugin::rabbitmq::password:  'guest'
+stackdriver::plugin::rabbitmq::queues:
+  - vhost:     '/'
+    host:      'localhost'
+    port:      '15672'
+    name:      '(First Queue Name)'
+    user:      'guest'
+    password:  'guest'
+  - vhost:     '/'
+    host:      'localhost'
+    port:      '15672'
+    name:      '(Second Queue Name)'
+    user:      'guest'
+    password:  'guest'
 ```
 
 

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -50,22 +50,19 @@
 class stackdriver::plugin::rabbitmq(
 
   $config   =  '/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf',
-  $vhost    = '%2F',
+  $host     = 'localhost',
+  $vhost    = '/',
   $port     = '15672',
   $queue    = undef,
   $user     = 'guest',
   $password = 'guest',
+  $queues   = [ { 'host' => $host, 'vhost' => $vhost, 'port' => $port, 'name' => $queue, 'user' => $user, 'password' => $password, }, ],
 
 ) {
 
   Class['stackdriver'] -> Class[$name]
 
-  validate_string ( $config   )
-  validate_string ( $vhost    )
-  validate_string ( $port     )
-  validate_string ( $user     )
-  validate_string ( $password )
-  validate_string ( $queue    )
+  validate_array  ( $queues   )
 
   contain "${name}::config"
 

--- a/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf.erb
+++ b/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf.erb
@@ -11,7 +11,7 @@ LoadPlugin target_set
         </Match>
         <Target "set">
             Plugin "rabbitmq"
-            PluginInstance "^<%= name %>$"
+            PluginInstance "<%= name %>"
         </Target>
     </Rule>
 

--- a/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf.erb
+++ b/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf.erb
@@ -2,16 +2,20 @@ LoadPlugin match_regex
 LoadPlugin target_set
 <Chain "PreCache">
     # Each queue needs a separate "Rule" section
+
+<% queue_names = queues.map{ |q| q.has_key?('name') ? q['name'] : '' }.uniq.each do |name| -%>
     <Rule>
         <Match regex>
             Plugin "^curl_json$"
-            PluginInstance "<%= @queue %>"
+            PluginInstance "^<%= name %>$"
         </Match>
         <Target "set">
             Plugin "rabbitmq"
-            PluginInstance "<%= @queue %>"
+            PluginInstance "^<%= name %>$"
         </Target>
-  </Rule>
+    </Rule>
+
+<% end -%>
 </Chain>
 
 LoadPlugin "curl_json"
@@ -19,14 +23,13 @@ LoadPlugin "curl_json"
     # Each queue needs a separate "URL" section that points to
     # http://localhost:15672/api/queues/vhost/queue_name
     # Each URL section must match one of the Rules sections
-    #
-    # NOTE: The vhost and queue name must be url encoded
-    #              Being that the default vhost is a forward slash "/",
-    #              we encode this as "%2F" 
-    <URL "http://localhost:<%= @port %>/api/queues/<%= @vhost %>/<%= @queue %>">
-        Instance "<%= @queue %>"
-        User "<%= @user %>"
-        Password "<%= @password %>"
+
+<% queues.each do |queue| -%>
+<%     q = { 'host' => 'localhost', 'port' => '15672', 'vhost' => '/', 'name' => '', 'user' => 'guest', 'password' => 'guest' }.merge(queue) -%>
+    <URL "http://<%= q['host'] %>:<%= q['port'] %>/api/queues/<%= q['vhost'] =~ /%/ ? q['vhost'] : ERB::Util.url_encode(q['vhost']) %>/<%= q['name'] =~ /%/ ? q['name'] : ERB::Util.url_encode(q['name']) %>">
+        Instance "<%= q['name'] %>"
+        User "<%= q['user'] %>"
+        Password "<%= q['password'].gsub(/\\/){'\\'}.gsub(/\"/){'\"'} -%>"
 
         <Key "messages">
             Type "gauge"
@@ -47,4 +50,6 @@ LoadPlugin "curl_json"
             Type "gauge"
         </Key>
     </URL>
+
+<% end -%>
 </Plugin>

--- a/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf.erb
+++ b/templates/Linux/opt/stackdriver/collectd/etc/collectd.d/rabbitmq.conf.erb
@@ -29,7 +29,7 @@ LoadPlugin "curl_json"
     <URL "http://<%= q['host'] %>:<%= q['port'] %>/api/queues/<%= q['vhost'] =~ /%/ ? q['vhost'] : ERB::Util.url_encode(q['vhost']) %>/<%= q['name'] =~ /%/ ? q['name'] : ERB::Util.url_encode(q['name']) %>">
         Instance "<%= q['name'] %>"
         User "<%= q['user'] %>"
-        Password "<%= q['password'].gsub(/\\/){'\\'}.gsub(/\"/){'\"'} -%>"
+        Password "<%= Regexp::quote(q['password']) -%>"
 
         <Key "messages">
             Type "gauge"


### PR DESCRIPTION
Extending the Rabbitmq configuration to support multiple queues in a back-compatible way.  Also fixed the url encoding problem and added the needed escapes to the Rabbitmq password(s) to protect them from shell expansion of special characters.