### PR TITLE
Change composition of classes in order to resolve containment issues

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,7 @@
+class stackdriver::config{
+  # OS Family specific configuration
+  class { $::stackdriver::cclass:
+    apikey => $::stackdriver::apikey,
+  }
+  contain $::stackdriver::cclass
+}

--- a/manifests/config/debian.pp
+++ b/manifests/config/debian.pp
@@ -15,6 +15,7 @@
 # - Stackdriver configuration file
 #
 class stackdriver::config::debian(
+  $apikey, 
   $sysconfig = '/etc/default/stackdriver-agent',
 ) {
 

--- a/manifests/config/debian.pp
+++ b/manifests/config/debian.pp
@@ -15,10 +15,8 @@
 # - Stackdriver configuration file
 #
 class stackdriver::config::debian(
-
   $sysconfig = '/etc/default/stackdriver-agent',
-
-) inherits stackdriver {
+) {
 
   validate_string ( $sysconfig )
 
@@ -28,7 +26,6 @@ class stackdriver::config::debian(
     group   => 'root',
     mode    => '0440',  # secure API key
     content => template("stackdriver/${::kernel}/${sysconfig}.erb"),
-    notify  => Service[$svc],
   }
 
 }

--- a/manifests/config/redhat.pp
+++ b/manifests/config/redhat.pp
@@ -15,11 +15,9 @@
 # - Stackdriver configuration file
 #
 class stackdriver::config::redhat(
-
+  $apikey,
   $sysconfig = '/etc/sysconfig/stackdriver',
-
-) inherits stackdriver {
-
+) {
   validate_string ( $sysconfig )
 
   file { $sysconfig:
@@ -28,8 +26,6 @@ class stackdriver::config::redhat(
     group   => 'root',
     mode    => '0440',  # secure API key
     content => template("stackdriver/${::kernel}/${sysconfig}.erb"),
-    notify  => Service[$svc],
   }
-
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,57 +23,35 @@
 #    apikey => "OMGBECKYLOOKATHERBUTTITSJUSTSOROUND"
 #  }
 #
-class stackdriver (
-
-  $apikey = undef,
-  $ensure = 'present',
+class stackdriver(
+  $apikey         = undef,
+  $ensure         = 'present',
   $service_ensure = 'running',
   $service_enable = true,
-
+  $plugins        = [],
   $svc = $::osfamily ? {
     'RedHat'  => [ 'stackdriver-agent', 'stackdriver-extractor' ],
     'Debian'  => [ 'stackdriver-agent', 'stackdriver-extractor' ],
     default   => undef,
   },
-
+  $iclass = "::stackdriver::install::${::osfamily}",
+  $cclass = "::stackdriver::config::${::osfamily}",
 ) {
-
   validate_string ( $apikey )
   validate_array  ( $svc    )
 
-  # Runtime class definitions
-  $iclass = "${name}::install::${::osfamily}"
-  $cclass = "${name}::config::${::osfamily}"
-  $sclass = "${name}::service"
+  contain stackdriver::install
+  contain stackdriver::config
+  contain stackdriver::service
 
-
-  # OS Family specific installation
-  class { "::${iclass}":
-    ensure => $ensure,
-    notify => Class[$sclass],
-  }
-  contain $iclass
-
-
-  # OS Family specific configuration
-  class { "::${cclass}": require => Class[$iclass]; }
-  contain $cclass
-
-
-  # Service
-  class { "::${sclass}":
-    service_ensure => $service_ensure,
-    service_enable => $service_enable,
-    require        => Class[$cclass],
-  }
-  include $sclass
-
-  # Array of Plugins to load (optional)
-  $plugins = hiera_array("${name}::plugins", [])
+  Class['::stackdriver::install'] -> Class['::stackdriver::config']
+  Class['::stackdriver::install'] ~> Class['::stackdriver::service'] 
+  Class['::stackdriver::config'] ~> Class['::stackdriver::service'] 
 
   if ! empty($plugins) {
     stackdriver::plugin { $plugins: }
   }
+
 
 }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,7 @@
+class stackdriver::install{
+  # OS Family specific installation
+  class { $::stackdriver::iclass:
+    ensure => $stackdriver::ensure,
+  }
+  contain $::stackdriver::iclass
+}

--- a/manifests/install/redhat.pp
+++ b/manifests/install/redhat.pp
@@ -31,7 +31,7 @@
 #
 class stackdriver::install::redhat(
 
-  $pkg    = [ 'stackdriver-agent', 'stackdriver-extractor' ],
+  $pkg    = [ 'stackdriver-extractor','stackdriver-agent'],
   $ensure = 'present',
 
   $repo = {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,31 +1,10 @@
-# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2 foldmethod=marker
-#
-# == Define: stackdriver::plugin
-#
-# Loads a Plugin for the Stackdriver Agent
-#
-#   NOTE: plugin configuration parameters should be defined via Hiera
-#
-# === Parameters
-# ---
-#
-# [*name*]
-# - Default - NONE (REQUIRED)
-# - Stackdriver plugin name
-#
-# == Examples:
-#
-#  stackdriver::plugin { 'elasticsearch': }
-#
-define stackdriver::plugin() {
-
+define stackdriver::plugin(){
   $pclass = "::stackdriver::plugin::${name}"
 
   if ! defined($pclass) {
     fail("Unknown Stackdriver Agent plugin ${name}")
+  } else {
+    contain $pclass
+
   }
-
-  include $pclass
-
 }
-

--- a/manifests/plugin/apache.pp
+++ b/manifests/plugin/apache.pp
@@ -40,26 +40,22 @@
 #   - 'apache'
 #
 class stackdriver::plugin::apache(
-
   $config   =  '/opt/stackdriver/collectd/etc/collectd.d/apache.conf',
-
   $url      = 'http://127.0.0.1/mod_status?auto',
   $user     = undef,
   $password = undef,
-
 ) {
-
-  Class['stackdriver'] -> Class[$name]
 
   validate_string ( $config )
   validate_string ( $url    )
   if $user      { validate_string ( $user     ) }
   if $password  { validate_string ( $password ) }
 
-  #contain "${name}::install"
-
-  #class { "::${name}::config": require => Class["::${name}::install"] }
   contain "${name}::config"
+
+  Class['::stackdriver::config'] -> 
+  Class["::${name}::config"] ~> 
+  Class['::stackdriver::service']
 
 }
 

--- a/manifests/plugin/elasticsearch.pp
+++ b/manifests/plugin/elasticsearch.pp
@@ -42,30 +42,24 @@
 #   - 'elasticsearch'
 #
 class stackdriver::plugin::elasticsearch(
-
   $pkg = $::osfamily ? {
     /(?i:Debian)/   => 'libyajl1',
     /(?i:RedHat)/   => 'yajl',
     default         => undef,
   },
-
   $config = '/opt/stackdriver/collectd/etc/collectd.d/elasticsearch.conf',
-
   $host     = 'localhost',
   $port     = 9200,
-
 ) {
-
-  Class['stackdriver'] -> Class[$name]
-
   if $pkg { validate_string ( $pkg ) }
   validate_string ( $config )
 
-
   contain "${name}::install"
-
-  class { "::${name}::config": require => Class["::${name}::install"] }
   contain "${name}::config"
 
+  Class['::stackdriver::config'] -> 
+  Class["::${name}::install"] ->
+  Class["::${name}::config"] ~> 
+  Class['::stackdriver::service']
 }
 

--- a/manifests/plugin/memcached.pp
+++ b/manifests/plugin/memcached.pp
@@ -44,12 +44,14 @@ class stackdriver::plugin::memcached(
 
 ) {
 
-  Class['stackdriver'] -> Class[$name]
-
   validate_string ( $config )
   validate_string ( $host   )
 
   contain "${name}::config"
+
+  Class['::stackdriver::config'] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 
 }
 

--- a/manifests/plugin/mongo.pp
+++ b/manifests/plugin/mongo.pp
@@ -44,27 +44,23 @@
 #   - 'mongo'
 #
 class stackdriver::plugin::mongo(
-
   $config   =  '/opt/stackdriver/collectd/etc/collectd.d/mongo.conf',
-
   $host     = 'localhost',
   $port     = 27017,
   $user     = 'stackdriver',
   $password = 'ahzae8aiLiKoe',
-
 ) {
-
-  Class['stackdriver'] -> Class[$name]
 
   validate_string ( $config   )
   validate_string ( $host     )
   validate_string ( $user     )
   validate_string ( $password )
 
-  #contain "${name}::install"
-
-  #class { "::${name}::config": require => Class["::${name}::install"] }
   contain "${name}::config"
+
+  Class['::stackdriver::config'] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 
 }
 

--- a/manifests/plugin/nginx.pp
+++ b/manifests/plugin/nginx.pp
@@ -64,8 +64,6 @@ class stackdriver::plugin::nginx(
 
 ) {
 
-  Class['stackdriver'] -> Class[$name]
-
   validate_absolute_path  ( $config )
   validate_string         ( $url    )
 
@@ -75,10 +73,11 @@ class stackdriver::plugin::nginx(
   if $verifyhost  != undef { validate_bool          ( $verifyhost ) }
   if $cacert      != undef { validate_absolute_path ( $cacert     ) }
 
-  #contain "${name}::install"
-
-  #class { "::${name}::config": require => Class["::${name}::install"] }
   contain "${name}::config"
+
+  Class['::stackdriver::config'] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 
 }
 

--- a/manifests/plugin/nginx/config.pp
+++ b/manifests/plugin/nginx/config.pp
@@ -5,8 +5,6 @@
 # Configures Nginx Agent Plugin for Stackdriver Agent
 #
 class stackdriver::plugin::nginx::config(
-
-
 ) inherits stackdriver::plugin::nginx {
 
   file { $config:
@@ -15,7 +13,6 @@ class stackdriver::plugin::nginx::config(
     owner   => 'root',
     group   => 'root',
     mode    => '0440', # secure
-    notify  => Service[$::stackdriver::svc],
   }
 
 }

--- a/manifests/plugin/postgres.pp
+++ b/manifests/plugin/postgres.pp
@@ -40,26 +40,22 @@
 #   - 'postgres'
 #
 class stackdriver::plugin::postgres(
-
   $config   =  '/opt/stackdriver/collectd/etc/collectd.d/postgres.conf',
-
   $dbname   = undef,  # REQUIRED Param
   $user     = 'stackdriver',
   $password = 'xoiboov9Pai5e',
-
 ) {
-
-  Class['stackdriver'] -> Class[$name]
 
   validate_string ( $config   )
   validate_string ( $dbname   )
   validate_string ( $user     )
   validate_string ( $password )
 
-  #contain "${name}::install"
-
-  #class { "::${name}::config": require => Class["::${name}::install"] }
   contain "${name}::config"
+
+  Class['::stackdriver::config'] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 
 }
 

--- a/manifests/plugin/rabbitmq.pp
+++ b/manifests/plugin/rabbitmq.pp
@@ -60,7 +60,6 @@ class stackdriver::plugin::rabbitmq(
 
 ) {
 
-  Class['stackdriver'] -> Class[$name]
 
   validate_array  ( $queues   )
 
@@ -70,6 +69,10 @@ class stackdriver::plugin::rabbitmq(
   ensure_resource('package', 'yajl', {
     'ensure'  => 'present',
   })
+
+  Class['::stackdriver::config'] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 
 }
 

--- a/manifests/plugin/rabbitmq/config.pp
+++ b/manifests/plugin/rabbitmq/config.pp
@@ -5,8 +5,6 @@
 # Configures RabbitMQ Agent Plugin for Stackdriver Agent
 #
 class stackdriver::plugin::rabbitmq::config(
-
-
 ) inherits stackdriver::plugin::rabbitmq {
 
   file { $config:

--- a/manifests/plugin/redis.pp
+++ b/manifests/plugin/redis.pp
@@ -45,27 +45,23 @@
 #   - 'redis'
 #
 class stackdriver::plugin::redis(
-
   $pkg      = 'hiredis-devel',
-
   $config   =  '/opt/stackdriver/collectd/etc/collectd.d/redis.conf',
-
   $host     = 'localhost',
   $port     = 6379,
   $timeout  = 2000,
 
 ) {
 
-  Class['stackdriver'] -> Class[$name]
-
   validate_string ( $pkg    )
   validate_string ( $config )
   validate_string ( $host   )
 
   contain "${name}::install"
-
-  class { "::${name}::config": require => Class["::${name}::install"] }
   contain "${name}::config"
 
+  Class['::stackdriver::config'] ->
+  Class["::${name}::install"] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 }
-

--- a/manifests/plugin/tomcat.pp
+++ b/manifests/plugin/tomcat.pp
@@ -57,8 +57,6 @@ class stackdriver::plugin::tomcat(
   $apikey    = hiera('stackdriver::apikey'),
 ) {
 
-  Class['stackdriver'] -> Class[$name]
-
   validate_string ( $ensure )
   validate_string ( $host   )
   validate_string ( $port   )
@@ -72,5 +70,9 @@ class stackdriver::plugin::tomcat(
   }
 
   contain "${name}::config"
+
+  Class['::stackdriver::config'] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 
 }

--- a/manifests/plugin/zookeeper.pp
+++ b/manifests/plugin/zookeeper.pp
@@ -43,13 +43,15 @@ class stackdriver::plugin::zookeeper(
 
 ) {
 
-  Class['stackdriver'] -> Class[$name]
-
   validate_string ( $config )
   validate_string ( $host   )
   validate_string ( $port   )
 
   contain "${name}::config"
+
+  Class['::stackdriver::config'] ->
+  Class["::${name}::config"] ~>
+  Class['::stackdriver::service']
 
 }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,18 +1,6 @@
-# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2 foldmethod=marker
-#
-# == Class: stackdriver::service
-#
-# Manages Stackdriver Agent Service
-#
-class stackdriver::service(
-  $service_ensure = 'running',
-  $service_enable = true,
-  ) inherits stackdriver {
-
-    service { $svc:
-      ensure => $service_ensure,
-      enable => $service_enable,
+class stackdriver::service{
+  service { $stackdriver::svc:
+    ensure => $stackdriver::service_ensure,
+    enable => $stackdriver::service_enable,
   }
-
 }
-


### PR DESCRIPTION
1) replace 'include' with 'contain' - this will make all subclasses of the module to be contained by base class
2) make plugins follow general sequence and reload stackdriver services in uniform way
3) stackdriver::config::redhat and stackdriver::config::debian explicitely require $apikey (otherwise stackdriver agent won't start)
4) remove inheritance from base class "inherits stackdriver", as it caused all containment issues. Subclasses should access 'global' level parameters from 'class stackdriver' using full name: $stackdriver::ensure, $stackdriver::svc
5) moved installation and configuration parts to own submodules, just to keep base class cleaner:
 contain stackdriver::install
 contain stackdriver::config
 contain stackdriver::service  