### PR TITLE
Add Puppet 4.x and PE compatibility + add flag to enable/disable repo management.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,8 +42,8 @@ class stackdriver (
   validate_array  ( $svc    )
 
   # Runtime class definitions
-  $iclass = "${name}::install::${::osfamily}"
-  $cclass = "${name}::config::${::osfamily}"
+  $iclass = downcase("${name}::install::${::osfamily}")
+  $cclass = downcase("${name}::config::${::osfamily}")
   $sclass = "${name}::service"
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,10 @@
 # - Default - Depends on $::osfamily
 # - Stackdriver Agent service name
 #
+# [*managerepo*]
+# - Default - true
+# - Should we add the upstream repository to the apt/Yum sources list?
+#
 # == Examples:
 #
 #  Basic agent configuration
@@ -27,6 +31,7 @@ class stackdriver (
 
   $apikey = undef,
   $ensure = 'present',
+  $managerepo = true,
   $service_ensure = 'running',
   $service_enable = true,
 

--- a/manifests/install/debian.pp
+++ b/manifests/install/debian.pp
@@ -60,17 +60,20 @@ class stackdriver::install::debian(
   validate_hash   ( $aptkey     )
   validate_hash   ( $aptsource  )
 
-  # Setup repo
-  ensure_resource('apt::key', 'stackdriver', $aptkey)
+  # Setup repo unless configure not to.
+  if $managerepo {
+    Apt::Source {
+      require => Apt::Key['stackdriver'],
+      before  => Package[$pkg],
+    }
 
-  Apt::Source { require => Apt::Key['stackdriver'], }
-
-  ensure_resource('apt::source', 'stackdriver', $aptsource)
+    ensure_resource('apt::key', 'stackdriver', $aptkey)
+    ensure_resource('apt::source', 'stackdriver', $aptsource)
+  }
 
   # Install package
   ensure_resource('package', $pkg, {
     'ensure'  => $ensure,
-    'require' => Apt::Source['stackdriver'],
   })
 
 }

--- a/manifests/install/redhat.pp
+++ b/manifests/install/redhat.pp
@@ -48,13 +48,18 @@ class stackdriver::install::redhat(
   validate_string ( $ensure )
   validate_hash   ( $repo   )
 
-  # Setup repo
-  ensure_resource('yumrepo', 'stackdriver-agent', $repo)
+  # Setup repo unless configure not to.
+  if $managerepo {
+    Yumrepo {
+      before  => Package[$pkg],
+    }
+
+    ensure_resource('yumrepo', 'stackdriver-agent', $repo)
+  }
 
   # Install package
   ensure_resource('package', $pkg, {
     'ensure'  => $ensure,
-    'require' => Yumrepo['stackdriver-agent']
   })
 
 }


### PR DESCRIPTION
Added "downcase" function around use of $::osfamily in init.pp as the class autoloader in Puppet 4.x is case sensitive.  I haven't tested extensively, but this is the only obvious show-stopper for Puppet 4.x compatibility.  This like applies to Puppet Enterprise as well, but I have not tested.

Added a new flag "managerepo" to enable the user prevent the module from managing the apt sources.  It's a common approach in modules of this type where systems may be configured against a locally managed package repository such as Aptly.
